### PR TITLE
Change apply to call

### DIFF
--- a/metadog.js
+++ b/metadog.js
@@ -59,7 +59,7 @@
 				}
 			}
 			var itemprops = this._document.querySelectorAll('[itemprop]');
-			setProps.apply(this, itemprops);
+			setProps.call(this, itemprops);
 		};
 
 		Metadog.prototype._mapToModel = function() {


### PR DESCRIPTION
Apply invokes function with arguments placed into first argument. Call invokes with all arguments after first. So, with apply setProps gets 'itemprops' not as array but list of array items. It causes the error when 'itemprops' is empty, because 'set' is undefined in this case.
